### PR TITLE
Passage target ES2020

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "ES2020",
         "declaration": true,
         "module": "ES2020",
         "sourceMap": true,


### PR DESCRIPTION
Afin de ne plus avoir de require dans le package buildé, il me semble que passer à un target ES2020 va résoudre le problème.